### PR TITLE
Remove noisy warnings and one error from Debugging logs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Made by UVic Game Dev
 
 ## Foundation Team:
 * Brendan "Sikowny"
-* Your name here
+* Colton Molton Bolton
 
 ## Robot Master Team:
 ### Intro / Robot Master 1

--- a/enemy_hitbox.gd
+++ b/enemy_hitbox.gd
@@ -14,7 +14,7 @@ func _ready() -> void:
 
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
-func _process(delta: float) -> void:
+func _process(_delta: float) -> void:
 	pass
 
 func handle_death():

--- a/enemy_test.gd
+++ b/enemy_test.gd
@@ -113,8 +113,8 @@ func handle_death():
 		explode.position = position + Vector2(0,-8)
 		
 		#drop item maybe
-		var item_chance = randi_range(1,100);
-		#if(item_chance <= 25):
+		var _item_chance = randi_range(1,100);
+		#if(_item_chance <= 25):
 		if(true):
 			var item_type = randi_range(0,2);
 			var size = randi_range(0,1);

--- a/enemy_test.gd
+++ b/enemy_test.gd
@@ -158,9 +158,9 @@ func connect_with_spawner(spawner_ID):
 func handle_despawn():
 	#when off screen
 	#handle any spawner communication if needed
-	if(is_instance_id_valid(SPAWNER_INSTANCE)):
-		var spawner = instance_from_id(SPAWNER_INSTANCE);
-		assert(is_instance_valid(spawner))
+	#if(is_instance_id_valid(SPAWNER_INSTANCE)):
+		#var spawner = instance_from_id(SPAWNER_INSTANCE);
+		#assert(is_instance_valid(spawner))
 		#spawner.ENEMY_INST_ID = -1; #not needed
 	queue_free();
 

--- a/scenes/Title Screen/title_screen.gd
+++ b/scenes/Title Screen/title_screen.gd
@@ -6,7 +6,7 @@ func _ready():
 	pass # Replace with function body.
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
-func _process(delta):
+func _process(_delta):
 	if(input_accept()): goto_menu();
 
 func goto_menu():

--- a/scenes/camera/omega_camera_2D.gd
+++ b/scenes/camera/omega_camera_2D.gd
@@ -19,7 +19,7 @@ func _ready() -> void:
 	Global.camera_spawn.emit(self)
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
-func _process(delta: float) -> void:
+func _process(_delta: float) -> void:
 	find_player()
 	process_camera_page_screen()
 	follow_instance_horizontally()

--- a/scenes/ladder_zone_top.gd
+++ b/scenes/ladder_zone_top.gd
@@ -11,7 +11,7 @@ func _ready():
 
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
-func _physics_process(delta):
+func _physics_process(_delta):
 	platform.disabled = false;
 	check_player_climb_down()
 	pass

--- a/scenes/level_script.gd
+++ b/scenes/level_script.gd
@@ -8,5 +8,5 @@ func _ready() -> void:
 
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
-func _process(delta: float) -> void:
+func _process(_delta: float) -> void:
 	pass

--- a/scenes/level_select/level_select_boss_choice_margin_container.gd
+++ b/scenes/level_select/level_select_boss_choice_margin_container.gd
@@ -12,7 +12,7 @@ var hover_timer_max = 8;
 func _ready():
 	hovering_sprite.visible = false;
 
-func _process(delta: float) -> void:
+func _process(_delta: float) -> void:
 	if(inputLock): grab_focus() #really bad way of doing this
 	
 	if (!has_focus()):
@@ -25,7 +25,7 @@ func _process(delta: float) -> void:
 	modulate = Color.WHITE
 	flash_border();
 	if(input_accept()):
-		signal_enter_level(level);
+		signal_enter_level();
 	
 func flash_border():
 	if(hover_timer == 0):
@@ -36,7 +36,7 @@ func flash_border():
 func input_accept():
 	return Input.is_action_pressed("act_jump")
 	
-func signal_enter_level(level):
+func signal_enter_level():
 	#check if level valid
 	if level < 1 or level > 9: return;
 	#signal level transition

--- a/scenes/level_select/level_select_screen.gd
+++ b/scenes/level_select/level_select_screen.gd
@@ -16,7 +16,7 @@ func _ready():
 	omega.grab_focus()
 	white_flash.visible = false;
 	
-func _process(delta):
+func _process(_delta):
 	if(!level_selected): return
 	flash_screen();
 	if(flash_timer == 0): goto_boss_intro();

--- a/scenes/triggers/trigger_kill_player.gd
+++ b/scenes/triggers/trigger_kill_player.gd
@@ -7,7 +7,7 @@ func _ready():
 
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
-func _process(delta):
+func _process(_delta):
 	pass
 
 func _on_body_entered(body):

--- a/scripts/item_pickup.gd
+++ b/scripts/item_pickup.gd
@@ -32,7 +32,7 @@ func _ready():
 			pass
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
-func _process(delta):
+func _process(_delta):
 	sprite.visible = true;
 	handle_animation();
 	handle_timer();

--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -308,7 +308,7 @@ func can_climb_ladder():
 		if(abs(input_move.y)): return true
 	return false
 	
-func try_damage(dmg,angle = 0):
+func try_damage(dmg, _angle = 0):
 	if(I_FRAMES != 0): return;
 	print("+++ player took damage +++")
 	damage_angle = PI * facing * -1;

--- a/scripts/player_debug_hud.gd
+++ b/scripts/player_debug_hud.gd
@@ -16,7 +16,7 @@ func _ready():
 
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
-func _process(delta):
+func _process(_delta):
 	#TODO how does this thing follow palyer???
 	
 	position_x.text = "X: " + str(snapped(player.position.x,0.01))


### PR DESCRIPTION
Lessons:
Warning:
* Let's use underscore prefixes on unused variables from now on. 
* A function overshadowed a class variable as a function argument, so that's fixed.

Error:
* A little piece of code that wasn't dubiously doing anything was using a null reference because it wasn't added with a spawner.

Unfixed:
* An error occurs when restarting a scene:
E 0:03:07:0642   player.gd:194 @ _physics_process(): Parameter "body->get_space()" is null.
  <C++ Source>   servers/physics_2d/godot_physics_server_2d.cpp:997 @ body_test_motion()
  <Stack Trace>  player.gd:194 @ _physics_process()
https://github.com/godotengine/godot/blob/15073afe3856abd2aa1622492fe50026c7d63dc1/servers/physics_2d/godot_physics_server_2d.cpp#L997

This error appears to have something to do with applying moving a characterbody2d collision when transitioning between two scenes. My assumption is this has something to do with the Player object persisting during a scene refresh because a reference is active inside the global. It's a little to coupled to the global singleton for me to just tweak and get rid of, so this PR won't affect it.